### PR TITLE
Ignore space scoped service brokers

### DIFF
--- a/export/exportconfig.go
+++ b/export/exportconfig.go
@@ -437,7 +437,7 @@ func (im *Manager) exportServiceAccess(globalConfig *config.GlobalConfig, orgs [
 	if err != nil {
 		return err
 	}
-	for _, broker := range serviceInfo.Brokers() {
+	for _, broker := range serviceInfo.StandardBrokers() {
 		brokerConfig := &config.Broker{
 			Name: broker.Name,
 		}

--- a/serviceaccess/service_broker.go
+++ b/serviceaccess/service_broker.go
@@ -3,8 +3,9 @@ package serviceaccess
 import "fmt"
 
 type ServiceBroker struct {
-	Name     string
-	services map[string]*Service
+	Name      string
+	SpaceGUID string
+	services  map[string]*Service
 }
 
 func (s *ServiceBroker) Services() []*Service {

--- a/serviceaccess/service_info.go
+++ b/serviceaccess/service_info.go
@@ -14,7 +14,8 @@ func GetServiceInfo(client CFClient) (*ServiceInfo, error) {
 	}
 	for _, broker := range brokers {
 		serviceBroker := &ServiceBroker{
-			Name: broker.Name,
+			Name:      broker.Name,
+			SpaceGUID: broker.SpaceGUID,
 		}
 		services, err := client.ListServicesByQuery(url.Values{
 			"q": []string{fmt.Sprintf("%s:%s", "service_broker_guid", broker.Guid)},
@@ -69,12 +70,18 @@ type ServiceInfo struct {
 	brokers map[string]*ServiceBroker
 }
 
-func (s *ServiceInfo) Brokers() []*ServiceBroker {
+func (s *ServiceInfo) StandardBrokers() []*ServiceBroker {
 	brokerList := []*ServiceBroker{}
 	for _, broker := range s.brokers {
-		brokerList = append(brokerList, broker)
+		if !isSpaceScopedServiceBroker(broker) {
+			brokerList = append(brokerList, broker)
+		}
 	}
 	return brokerList
+}
+
+func isSpaceScopedServiceBroker(broker *ServiceBroker) bool {
+	return broker.SpaceGUID != ""
 }
 
 func (s *ServiceInfo) GetBroker(brokerName string) (*ServiceBroker, error) {

--- a/serviceaccess/service_info_test.go
+++ b/serviceaccess/service_info_test.go
@@ -1,15 +1,60 @@
 package serviceaccess_test
 
 import (
+	cfclient "github.com/cloudfoundry-community/go-cfclient"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/vmwarepivotallabs/cf-mgmt/serviceaccess"
+	"github.com/vmwarepivotallabs/cf-mgmt/serviceaccess/fakes"
 )
 
 var _ = Describe("ServiceInfo", func() {
-	Context("GetPlan", func() {
-		It("Should find service plan", func() {
-			Expect(true).To(BeTrue())
+	Context("StandardBrokers", func() {
+		fakeClient := new(fakes.FakeCFClient)
+
+		It("returns standard brokers", func() {
+			standardBrokers := []cfclient.ServiceBroker{
+				cfclient.ServiceBroker{
+					Guid: "some-guid",
+					Name: "some-name",
+				},
+				cfclient.ServiceBroker{
+					Guid: "some-guid-2",
+					Name: "some-name-2",
+				},
+				cfclient.ServiceBroker{
+					Guid: "some-guid-3",
+					Name: "some-name-3",
+				},
+			}
+			var error error
+			fakeClient.ListServiceBrokersReturns(standardBrokers, error)
+
+			serviceInfo, _ := serviceaccess.GetServiceInfo(fakeClient)
+			Expect(serviceInfo.StandardBrokers()).Should(HaveLen(3))
 		})
 
+		It("does not return space scoped brokers", func() {
+			brokers := []cfclient.ServiceBroker{
+				cfclient.ServiceBroker{
+					Guid: "some-guid",
+					Name: "some-name",
+				},
+				cfclient.ServiceBroker{
+					Guid: "some-guid-2",
+					Name: "some-name-2",
+				},
+				cfclient.ServiceBroker{
+					Guid:      "some-guid-3",
+					Name:      "some-space-broker-name",
+					SpaceGUID: "non-empty-guid",
+				},
+			}
+			var error error
+			fakeClient.ListServiceBrokersReturns(brokers, error)
+
+			serviceInfo, _ := serviceaccess.GetServiceInfo(fakeClient)
+			Expect(serviceInfo.StandardBrokers()).Should(HaveLen(2))
+		})
 	})
 })

--- a/serviceaccess/serviceaccess.go
+++ b/serviceaccess/serviceaccess.go
@@ -65,12 +65,12 @@ func (m *Manager) Apply() error {
 }
 
 func (m *Manager) UpdateServiceAccess(globalCfg *config.GlobalConfig, serviceInfo *ServiceInfo, protectedOrgs []string) error {
-
 	if !globalCfg.EnableServiceAccess {
 		lo.G.Info("Service Access is not enabled.  Set enable-service-access: true in cf-mgmt.yml")
 		return nil
 	}
-	for _, broker := range serviceInfo.Brokers() {
+
+	for _, broker := range serviceInfo.StandardBrokers() {
 		for _, service := range broker.Services() {
 			for _, plan := range service.Plans() {
 				planInfo := globalCfg.GetPlanInfo(broker.Name, service.Name, plan.Name)

--- a/serviceaccess/serviceaccess_test.go
+++ b/serviceaccess/serviceaccess_test.go
@@ -147,6 +147,32 @@ var _ = Describe("Serviceaccess", func() {
 			Expect(planGUID).Should(Equal("small-guid"))
 			Expect(orgGUID).Should(Equal("test-org-guid"))
 		})
+
+		When("The broker is space-scoped", func() {
+			It("does not attempt to make the broker's plans public", func() {
+				globalCfg := &config.GlobalConfig{
+					EnableServiceAccess: true,
+				}
+
+				spaceScopedBroker := &ServiceBroker{
+					Name:      "space-scoped-broker",
+					SpaceGUID: "9f815177-3eee-4d9c-a1d0-42db4f4b49a5",
+				}
+				service := &Service{
+					Name: "some-service",
+				}
+				service.AddPlan(&ServicePlanInfo{})
+				spaceScopedBroker.AddService(service)
+
+				serviceInfo := &ServiceInfo{}
+				serviceInfo.AddBroker(spaceScopedBroker)
+				protectedOrgs := []string{}
+
+				err := manager.UpdateServiceAccess(globalCfg, serviceInfo, protectedOrgs)
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(fakeCFClient.MakeServicePlanPublicCallCount()).Should(Equal(0))
+			})
+		})
 	})
 
 	Context("EnsurePublicAccess", func() {


### PR DESCRIPTION
* space scoped service brokers introduce a problem for service access #233
* service info now explicitly returns standard brokers only and not
  space broker

[#174118740]