### PR TITLE
Add 'p-*' to DefaultProtectedOrgs and set enable-delete-orgs to false by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Navigate into a directory in which will become your git repository for cf-mgmt c
    - [init](docs/config/init/README.md) command from `cf-mgmt-config` if you are wanting to start with a blank configuration and add the config using `cf-mgmt-config` operations
    - [export-config](docs/export-config/README.md) command from `cf-mgmt` if you have an existing foundation you can use this to reverse engineer your configuration.
 
+> By default, `cf-mgmt` has the `enable-delete-orgs` option set to `false` to avoid unintentional deletions. If you'd like to have `cf-mgmt` handle deletion of orgs as well, please double check the list of `protected-orgs` and update the `enable-delete-orgs` flag to true in the `orgs.yml` of your config repository.
+> You can also modify these settings using the [`cf-mgmt-config update-orgs` command](docs/config/update-orgs/README.md).
+
 > Check the [config docs](docs/config/README.md#global-config) to understand the configuration files structure
 
 3. *(optional)* Configure LDAP/SAML Options. If your foundation uses LDAP and/or SAML, you will need to configure ldap.yml with the correct values.

--- a/config/config.go
+++ b/config/config.go
@@ -9,7 +9,7 @@ var DefaultProtectedOrgs = []string{
 	"redis-test-ORG*",
 	"appdynamics-org",
 	"credhub-service-broker-org",
-	"p-*",
+	"^p-*",
 }
 
 // Manager can read and write the cf-mgmt configuration.

--- a/config/config.go
+++ b/config/config.go
@@ -5,12 +5,11 @@ package config
 // and should never be deleted by cf-mgmt.
 var DefaultProtectedOrgs = []string{
 	"system",
-	"p-spring-cloud-services",
 	"splunk-nozzle-org",
 	"redis-test-ORG*",
 	"appdynamics-org",
 	"credhub-service-broker-org",
-	"p-dataflow",
+	"p-*",
 }
 
 // Manager can read and write the cf-mgmt configuration.

--- a/config/org_test.go
+++ b/config/org_test.go
@@ -22,17 +22,16 @@ var _ = Describe("Org", func() {
 	Context("Should merge protected org list with default protected orgs", func() {
 		It("should not include duplicates", func() {
 			org := &Orgs{
-				ProtectedOrgs: []string{"p-dataflow", "protect-me"},
+				ProtectedOrgs: []string{"system", "protect-me"},
 			}
 			protectedOrgList := org.ProtectedOrgList()
-			Expect(protectedOrgList).Should(HaveLen(8))
+			Expect(protectedOrgList).Should(HaveLen(7))
 			Expect(protectedOrgList).Should(ContainElement("system"))
-			Expect(protectedOrgList).Should(ContainElement("p-spring-cloud-services"))
 			Expect(protectedOrgList).Should(ContainElement("splunk-nozzle-org"))
 			Expect(protectedOrgList).Should(ContainElement("redis-test-ORG*"))
 			Expect(protectedOrgList).Should(ContainElement("appdynamics-org"))
 			Expect(protectedOrgList).Should(ContainElement("credhub-service-broker-org"))
-			Expect(protectedOrgList).Should(ContainElement("p-dataflow"))
+			Expect(protectedOrgList).Should(ContainElement("p-*"))
 			Expect(protectedOrgList).Should(ContainElement("protect-me"))
 		})
 	})

--- a/config/org_test.go
+++ b/config/org_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Org", func() {
 			Expect(protectedOrgList).Should(ContainElement("redis-test-ORG*"))
 			Expect(protectedOrgList).Should(ContainElement("appdynamics-org"))
 			Expect(protectedOrgList).Should(ContainElement("credhub-service-broker-org"))
-			Expect(protectedOrgList).Should(ContainElement("p-*"))
+			Expect(protectedOrgList).Should(ContainElement("^p-*"))
 			Expect(protectedOrgList).Should(ContainElement("protect-me"))
 		})
 	})

--- a/config/yaml_config.go
+++ b/config/yaml_config.go
@@ -495,7 +495,7 @@ func (m *yamlManager) CreateConfigIfNotExists(uaaOrigin string) error {
 	}
 
 	if err := WriteFile(fmt.Sprintf("%s/orgs.yml", m.ConfigDir), &Orgs{
-		EnableDeleteOrgs: true,
+		EnableDeleteOrgs: false,
 		ProtectedOrgs:    DefaultProtectedOrgs,
 	}); err != nil {
 		return err

--- a/config/yaml_config_test.go
+++ b/config/yaml_config_test.go
@@ -15,14 +15,13 @@ var _ = Describe("CF-Mgmt Config", func() {
 	Context("Protected Org Defaults", func() {
 		Describe("Defaults", func() {
 			It("should setup default protected orgs", func() {
-				Expect(config.DefaultProtectedOrgs).Should(HaveLen(7))
+				Expect(config.DefaultProtectedOrgs).Should(HaveLen(6))
 				Expect(config.DefaultProtectedOrgs).Should(ContainElement("system"))
-				Expect(config.DefaultProtectedOrgs).Should(ContainElement("p-spring-cloud-services"))
 				Expect(config.DefaultProtectedOrgs).Should(ContainElement("splunk-nozzle-org"))
 				Expect(config.DefaultProtectedOrgs).Should(ContainElement("redis-test-ORG*"))
 				Expect(config.DefaultProtectedOrgs).Should(ContainElement("appdynamics-org"))
 				Expect(config.DefaultProtectedOrgs).Should(ContainElement("credhub-service-broker-org"))
-				Expect(config.DefaultProtectedOrgs).Should(ContainElement("p-dataflow"))
+				Expect(config.DefaultProtectedOrgs).Should(ContainElement("p-*"))
 			})
 		})
 	})

--- a/config/yaml_config_test.go
+++ b/config/yaml_config_test.go
@@ -21,7 +21,7 @@ var _ = Describe("CF-Mgmt Config", func() {
 				Expect(config.DefaultProtectedOrgs).Should(ContainElement("redis-test-ORG*"))
 				Expect(config.DefaultProtectedOrgs).Should(ContainElement("appdynamics-org"))
 				Expect(config.DefaultProtectedOrgs).Should(ContainElement("credhub-service-broker-org"))
-				Expect(config.DefaultProtectedOrgs).Should(ContainElement("p-*"))
+				Expect(config.DefaultProtectedOrgs).Should(ContainElement("^p-*"))
 			})
 		})
 	})

--- a/docs/config/update-orgs/README.md
+++ b/docs/config/update-orgs/README.md
@@ -4,6 +4,8 @@
 
 `update-orgs` command allows updating orgs.yml
 
+_**Note**: If you intend to enable the deletion of orgs, please double check your `protected-orgs` list in your `orgs.yml`. Consider adding any orgs that might be created as part of a Tile installation._
+
 ## Command Usage
 ```
 Usage:
@@ -15,4 +17,6 @@ Help Options:
 [update-orgs command options]
   --config-dir=                     Name of the config directory (default: config) [$CONFIG_DIR]
   --enable-delete-orgs=[true|false] Enable delete orgs option
+  --protected-org=                  Add org(s) to protected org list, specify multiple times
+  --protected-org-to-remove=        Remove org(s) from protected org list, specify multiple times
 ```

--- a/organization/orgs_test.go
+++ b/organization/orgs_test.go
@@ -121,7 +121,7 @@ var _ = Describe("given OrgManager", func() {
 	})
 
 	Context("DeleteOrgs()", func() {
-		It("should delete 1", func() {
+		It("should delete 2", func() {
 			fakeReader.OrgsReturns(&config.Orgs{
 				EnableDeleteOrgs: true,
 				Orgs:             []string{"test"},
@@ -146,6 +146,10 @@ var _ = Describe("given OrgManager", func() {
 					Guid: "redis-guid",
 				},
 				cfclient.Org{
+					Name: "mop-bucket",
+					Guid: "some-org-that-matches-p-",
+				},
+				cfclient.Org{
 					Name: "p-some-tile",
 					Guid: "p-tile-guid",
 				},
@@ -153,9 +157,11 @@ var _ = Describe("given OrgManager", func() {
 			fakeOrgReader.ListOrgsReturns(orgs, nil)
 			err := orgManager.DeleteOrgs()
 			Ω(err).Should(BeNil())
-			Expect(fakeClient.DeleteOrgCallCount()).Should(Equal(1))
+			Expect(fakeClient.DeleteOrgCallCount()).Should(Equal(2))
 			orgGUID, _, _ := fakeClient.DeleteOrgArgsForCall(0)
 			Expect(orgGUID).Should(Equal("test2-guid"))
+			orgGUID, _, _ = fakeClient.DeleteOrgArgsForCall(1)
+			Expect(orgGUID).Should(Equal("some-org-that-matches-p-"))
 		})
 	})
 

--- a/organization/orgs_test.go
+++ b/organization/orgs_test.go
@@ -145,6 +145,10 @@ var _ = Describe("given OrgManager", func() {
 					Name: "redis-test-ORG-1-2017_10_04-20h06m33.481s",
 					Guid: "redis-guid",
 				},
+				cfclient.Org{
+					Name: "p-some-tile",
+					Guid: "p-tile-guid",
+				},
 			}
 			fakeOrgReader.ListOrgsReturns(orgs, nil)
 			err := orgManager.DeleteOrgs()


### PR DESCRIPTION
We've heard multiple incidents of folks having tile-created orgs blown away. The intention behind this change is two-fold:
1. Make it a conscious decision for operators to set the `enable-delete-orgs` flag
2. Prevent orgs created by tiles from being deleted accidentally