### PR TITLE
adding support to set ldap tls min and max version

### DIFF
--- a/config/ldap.go
+++ b/config/ldap.go
@@ -19,4 +19,6 @@ type LdapConfig struct {
 	InsecureSkipVerify string `yaml:"insecure_skip_verify"`
 	CACert             string `yaml:"ca_cert"`
 	UseIDForSAMLUser   bool   `yaml:"useIDForSAMLUser"`
+	MinTLSVersion      string `yaml:"minTLSVersion"`
+	MaxTLSVersion      string `yaml:"maxTLSVersion"`
 }

--- a/docs/config/README.md
+++ b/docs/config/README.md
@@ -368,6 +368,10 @@ origin: ldap
 insecure_skip_verify: false
 # optional added in 1.0.11+ if ldap server is signed by non-public CA provide ca pem here
 ca_cert: |
+
+# optional added in 1.0.47+ if omitted 1.0 is min, 1.3 is max.  Valid values 1.0, 1.1, 1.2, 1.3 or blank
+minTLSVersion: 1.0
+maxTLSVersion: 1.3
 ```
 
 >When using LDAP with Active Directory, the `uid` for `userNameAttribute` should be a `sAMAccountName`
@@ -401,6 +405,10 @@ ca_cert: |
 
 # optional added in 1.0.37 - true/false.  If true it will use userid from ldap group lookup vs email address for userid
 useIDForSAMLUser: false
+
+# optional added in 1.0.47+ if omitted 1.0 is min, 1.3 is max.  Valid values 1.0, 1.1, 1.2, 1.3 or blank
+minTLSVersion: 1.0
+maxTLSVersion: 1.3
 ```
 
 ### SAML Configuration

--- a/ldap/connection_test.go
+++ b/ldap/connection_test.go
@@ -1,6 +1,7 @@
 package ldap_test
 
 import (
+	"crypto/tls"
 	"errors"
 
 	l "github.com/go-ldap/ldap"
@@ -168,3 +169,41 @@ func withCallCounter(callCounter *int, createConnection func() (ldap.Connection,
 		return createConnection()
 	}
 }
+
+var _ = Describe("MapTLSVersion", func() {
+	When("when 1.0", func() {
+		It("returns VersionTLS10", func() {
+			val, err := ldap.MapTLSVersion("1.0")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(val).Should(Equal(uint16(tls.VersionTLS10)))
+		})
+	})
+	When("when 1.1", func() {
+		It("returns VersionTLS11", func() {
+			val, err := ldap.MapTLSVersion("1.1")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(val).Should(Equal(uint16(tls.VersionTLS11)))
+		})
+	})
+	When("when 1.2", func() {
+		It("returns VersionTLS12", func() {
+			val, err := ldap.MapTLSVersion("1.2")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(val).Should(Equal(uint16(tls.VersionTLS12)))
+		})
+	})
+	When("when 1.3", func() {
+		It("returns VersionTLS13", func() {
+			val, err := ldap.MapTLSVersion("1.3")
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(val).Should(Equal(uint16(tls.VersionTLS13)))
+		})
+	})
+
+	When("when unknown value", func() {
+		It("returns error", func() {
+			_, err := ldap.MapTLSVersion("1.3.1")
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
This allows configuration to set min/max TLS version when interacting with ldap server over TLS